### PR TITLE
Adding capability for issuing refresh token as well as a refresh endpoint in auth controller api

### DIFF
--- a/src/main/java/com/alopez/store/config/JwtConfig.java
+++ b/src/main/java/com/alopez/store/config/JwtConfig.java
@@ -1,0 +1,21 @@
+package com.alopez.store.config;
+
+import io.jsonwebtoken.security.Keys;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import javax.crypto.SecretKey;
+
+@Configuration
+@ConfigurationProperties(prefix = "spring.jwt")
+@Data
+public class JwtConfig {
+    private String secret;
+    private int accessTokenTTL;
+    private int refreshTokenTTL;
+
+    public SecretKey getSecretKey() {
+        return Keys.hmacShaKeyFor(secret.getBytes());
+    }
+}

--- a/src/main/java/com/alopez/store/config/SecurityConfig.java
+++ b/src/main/java/com/alopez/store/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
@@ -17,6 +18,7 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @AllArgsConstructor
@@ -54,8 +56,12 @@ public class SecurityConfig {
                     .requestMatchers("/api/carts/**").permitAll()
                     .requestMatchers(HttpMethod.POST,"/api/users").permitAll()
                     .requestMatchers(HttpMethod.POST,"/api/auth/login").permitAll()
+                    .requestMatchers(HttpMethod.POST,"/api/auth/refresh").permitAll()
                     .anyRequest().authenticated()
-            ).addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+            )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .exceptionHandling( c ->
+                        c.authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)));
 
         return http.build();
     }

--- a/src/main/java/com/alopez/store/filters/JwtAuthenticationFilter.java
+++ b/src/main/java/com/alopez/store/filters/JwtAuthenticationFilter.java
@@ -30,7 +30,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         var token = authHeader.replace("Bearer ", "");
-        if (!jwtService.validateToken(token)) {
+        if (jwtService.isTokenExpired(token)) {
             filterChain.doFilter(request, response);
             return ;
         }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -9,3 +9,5 @@ spring:
     show-sql: true
   jwt:
     secret: ${JWT_SECRET}
+    accessTokenTTL: 300 # 5m
+    refreshTokenTTL: 604800 # 7d


### PR DESCRIPTION
## Summary
This Pull Request adds support for refresh tokens, updates the JWT implementation for better manageability using configuration properties, and introduces necessary adjustments to authentication flow and related files.


## Main Changes
 - Added JwtConfig class for managing JWT properties through configuration (secret, accessTokenTTL, and refreshTokenTTL).
 - Updated SecurityConfig to include exception handling for unauthorized requests and added support for the refresh token endpoint.
 - Modified AuthController to implement a /refresh endpoint, store refresh tokens in cookies, and update the login flow to generate access and refresh tokens.
 - Refactored JwtService
 - Split token generation into generateAccessToken and generateRefreshToken.
 - Added isTokenExpired for validating token expiration.
 - Centralized token signing key management via JwtConfig.
 - Updated JwtAuthenticationFilter to check for token expiration explicitly.
 - Modified application.yaml to include configurations for access and refresh token expiration times.